### PR TITLE
SCRUM-5: Run commands in vm with stdout, stdin, stderr

### DIFF
--- a/src/worker_node/core/qemu_controller.py
+++ b/src/worker_node/core/qemu_controller.py
@@ -93,8 +93,7 @@ class QemuController:
         if self.status != QemuStatus.STARTED:
             raise RuntimeError("QEMU is not STARTED. Cannot run command.")
         
-        if (not self.wait_for_ssh_connection()):
-            raise ConnectionError("SSH test connection failed. QEMU is not ready for command execution.")
+        self.wait_for_ssh_connection()
         
         self.status = QemuStatus.RUNNING
         cmd = " ".join(command)

--- a/src/worker_node/core/qemu_controller.py
+++ b/src/worker_node/core/qemu_controller.py
@@ -1,11 +1,9 @@
 import os
 import shutil
-import shlex
 import time
 import subprocess
 from pathlib import Path
 from enum import Enum
-
 from ..helpers.process import clean_proccess
 from ..helpers.socket import wait_for_file_socket_availability
 from ..config import BASE_IMG_FILE
@@ -101,7 +99,7 @@ class QemuController:
             self.status = QemuStatus.RUNNING
             cmd = f"python3 {file_name} {type}"
 
-            if (not self.check_ssh_connection()):
+            if (not self.wait_for_ssh_connection()):
                 raise ConnectionError("SSH test connection failed. QEMU is not ready for command execution.")
             
             self.ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
@@ -238,7 +236,7 @@ class QemuController:
         if proc.returncode != 0:
             raise RuntimeError(f"socat exited with error: \n{stderr}")
         
-    def wait_for_ssh_connection(self, port:int=2222, user:str="root", timeout:int=60) -> bool:
+    def wait_for_ssh_connection(self, port:int=2222, user:str="root",password:str="root", timeout:int=60) -> bool:
         """
         Poll SSH on localhost:port until authentication succeeds,
         meaning the server is ready for communication.

--- a/src/worker_node/core/qemu_controller.py
+++ b/src/worker_node/core/qemu_controller.py
@@ -4,9 +4,11 @@ import time
 import subprocess
 from pathlib import Path
 from enum import Enum
+from typing import List
 from ..helpers.process import clean_proccess
 from ..helpers.socket import wait_for_file_socket_availability
 from ..config import BASE_IMG_FILE
+from ..models.vm_output import VMOutput
 import paramiko
 
 class QemuStatus(Enum):
@@ -59,13 +61,9 @@ class QemuController:
             self.status = QemuStatus.STARTED
             print(f"VM booted in {self.boot_time:.2f} ms.")
 
-            self.status = QemuStatus.STARTED
         except FileNotFoundError:
             self.status = QemuStatus.STOPPED
             raise RuntimeError("QEMU img not found. Ensure that PATH to img is correct.")
-        except subprocess.CalledProcessError as e:
-            self.status = QemuStatus.STOPPED
-            raise RuntimeError(f"QEMU exited with an error code {e.returncode}. Command: {' '.join(command)}")
         except Exception as e:
             self.status = QemuStatus.STOPPED
             raise RuntimeError(f"An unexpected error occurred: {str(e)}")
@@ -90,38 +88,49 @@ class QemuController:
     def reset(self) -> None:
         ...
     
-    def run_command(self, file_name: str, type:str) -> str:
+    def run_command(self, command:List[str], timeout:int = 30) -> VMOutput:
         start_time = time.perf_counter()
         if self.status != QemuStatus.STARTED:
             raise RuntimeError("QEMU is not STARTED. Cannot run command.")
         
-        try:
-            self.status = QemuStatus.RUNNING
-            cmd = f"python3 {file_name} {type}"
-
-            if (not self.wait_for_ssh_connection()):
-                raise ConnectionError("SSH test connection failed. QEMU is not ready for command execution.")
-            
-            self.ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
-            self.ssh.connect("localhost", port=2222, username="root", password="root", timeout=1)
-
-            stdin, stdout, stderr = self.ssh.exec_command(cmd) #type:ignore
-            returncode = stdout.channel.recv_exit_status()
-
-            if returncode != 0:
-                return f"Error: {stderr.read().decode("utf-8")}"
-            
-            elapsed_time = (time.perf_counter() - start_time) * 1000
-            print(f"Command executed in {elapsed_time:.2f} ms.")
-            return f"Output: {stdout.read().decode("utf-8")}"
+        if (not self.wait_for_ssh_connection()):
+            raise ConnectionError("SSH test connection failed. QEMU is not ready for command execution.")
         
-        except paramiko.SSHException as e:
-            raise RuntimeError(f"SSH connection error: {str(e)}")
-        except Exception as e:
-            raise RuntimeError(f"An error occurred while running the command: {str(e)}")
-        finally:
-            self.status = QemuStatus.STARTED
-            self.ssh.close()
+        self.status = QemuStatus.RUNNING
+        cmd = " ".join(command)
+        error_buffer = ""
+
+        while (time.perf_counter() - start_time) < timeout:
+            try:
+                self.ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+                self.ssh.connect("localhost", port=2222, username="root", password="root", timeout=1)
+
+                _, stdout, stderr = self.ssh.exec_command(cmd)
+                returncode = stdout.channel.recv_exit_status()
+
+                output = VMOutput(
+                    stdin=cmd,
+                    stdout=stdout.read().decode("utf-8"),
+                    stderr=stderr.read().decode("utf-8"),
+                    returncode=returncode,
+                    runtime=f"{(time.perf_counter() - start_time) * 1000:.2f} ms"
+                )                    
+                return output
+
+            except RuntimeError as e:
+                error_buffer = f"Runtime error: {str(e)}\n"
+                time.sleep(1)
+            except paramiko.SSHException as e:
+                error_buffer = f"SSH error: {str(e)}\n"
+                time.sleep(1)
+            except Exception as e:
+                error_buffer = f"Unexpected error: {str(e)}\n"
+                time.sleep(1)
+            finally:
+                self.status = QemuStatus.STARTED
+                self.ssh.close()
+
+        raise TimeoutError(f"Command execution timed out after {timeout} seconds. Last known error: {error_buffer}")
 
     
     def get_status(self):
@@ -236,12 +245,14 @@ class QemuController:
         if proc.returncode != 0:
             raise RuntimeError(f"socat exited with error: \n{stderr}")
         
-    def wait_for_ssh_connection(self, port:int=2222, user:str="root",password:str="root", timeout:int=60) -> bool:
+    def wait_for_ssh_connection(self, port:int=2222, user:str="root",password:str="root", timeout:int=30) -> bool:
         """
         Poll SSH on localhost:port until authentication succeeds,
         meaning the server is ready for communication.
         """
-
+        # if self.status != QemuStatus.STARTED:
+        #     raise RuntimeError("QEMU is not STARTED. Cannot wait for SSH connection.")
+        
         start_time = time.perf_counter()
         while (time.perf_counter() - start_time) < timeout:
             try:

--- a/src/worker_node/core/qemu_controller.py
+++ b/src/worker_node/core/qemu_controller.py
@@ -280,6 +280,8 @@ class QemuController:
         """
         # if self.status != QemuStatus.STARTED:
         #     raise RuntimeError("QEMU is not STARTED. Cannot wait for SSH connection.")
+
+        return True;
         
         start_time = time.perf_counter()
         while (time.perf_counter() - start_time) < timeout:

--- a/src/worker_node/core/qemu_controller.py
+++ b/src/worker_node/core/qemu_controller.py
@@ -95,7 +95,7 @@ class QemuController:
             cmd = f"python3 {file_name} {type}"
 
             if (not self.check_ssh_connection()):
-                raise ConnectionError("SSH connection failed. QEMU is not ready for command execution.")
+                raise ConnectionError("SSH test connection failed. QEMU is not ready for command execution.")
             
             self.ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
             self.ssh.connect("localhost", port=2222, username="root", password="root", timeout=1)

--- a/src/worker_node/core/qemu_controller.py
+++ b/src/worker_node/core/qemu_controller.py
@@ -1,8 +1,10 @@
+import os # type:ignore
 from pathlib import Path
 from enum import Enum
 import subprocess
-import shlex
+import shlex # type:ignore
 import time
+import paramiko
 
 class QemuStatus(Enum):
     STARTED = 1
@@ -12,11 +14,12 @@ class QemuStatus(Enum):
 class QemuController:
     def __init__(self, img_path: Path, cpu_count: int = 1, memory_allocated: int = 0) -> None:
         self.img_path = img_path 
-        self.snapshot_name = "kvm-fastboot" #"base"
+        self.snapshot_name = "base"
         self.cpu_count = cpu_count
         self.memory_allocated = memory_allocated
         self.status = QemuStatus.STOPPED
         self.boot_time = 0
+        self.ssh = paramiko.SSHClient()
 
     def start(self):
         if self.img_path.exists() == False:
@@ -38,7 +41,6 @@ class QemuController:
         if self.status == QemuStatus.STARTED:
             raise RuntimeError("QEMU is already running")        
 
-        self.status = QemuStatus.STARTED
         try:
             start_time = time.perf_counter()
             
@@ -50,6 +52,7 @@ class QemuController:
             if (self.check_ssh_connection()):
                 self.boot_time = (time.perf_counter() - start_time)*1000
 
+            self.status = QemuStatus.STARTED
             print(f"VM booted in {self.boot_time:.2f} ms.")
 
         except FileNotFoundError:
@@ -82,41 +85,61 @@ class QemuController:
     def reset(self) -> None:
         ...
     
-    def run_command(self):
-        ...
+    def run_command(self, file_name: str, type:str) -> str:
+        start_time = time.perf_counter()
+        if self.status != QemuStatus.STARTED:
+            raise RuntimeError("QEMU is not STARTED. Cannot run command.")
+        
+        try:
+            self.status = QemuStatus.RUNNING
+            cmd = f"python3 {file_name} {type}"
+
+            if (not self.check_ssh_connection()):
+                raise ConnectionError("SSH connection failed. QEMU is not ready for command execution.")
+            
+            self.ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+            self.ssh.connect("localhost", port=2222, username="root", password="root", timeout=1)
+
+            stdin, stdout, stderr = self.ssh.exec_command(cmd) #type:ignore
+            returncode = stdout.channel.recv_exit_status()
+
+            if returncode != 0:
+                return f"Error: {stderr.read().decode("utf-8")}"
+            
+            elapsed_time = (time.perf_counter() - start_time) * 1000
+            print(f"Command executed in {elapsed_time:.2f} ms.")
+            return f"Output: {stdout.read().decode("utf-8")}"
+        
+        except paramiko.SSHException as e:
+            raise RuntimeError(f"SSH connection error: {str(e)}")
+        except Exception as e:
+            raise RuntimeError(f"An error occurred while running the command: {str(e)}")
+        finally:
+            self.status = QemuStatus.STARTED
+            self.ssh.close()
+
     
     def get_status(self):
         ...
-
-    def check_ssh_connection(self, port:int=2222, user:str="root", timeout:int=60) -> bool:
+    
+    def check_ssh_connection(self, port: int = 2222, user: str = "root", password:str ="root", timeout: int = 60) -> bool:
         """
-        Poll SSH on localhost:port until SSH responds with 'Permission denied',
-        indicating the server is up and requesting authentication.
+        Poll SSH on localhost:port until authentication succeeds,
+        meaning the server is ready for communication.
         """
-        ssh_cmd = (
-            f"ssh -p {port} -o StrictHostKeyChecking=no "
-            f"-o BatchMode=yes -o ConnectTimeout=1 {user}@localhost true"
-        )
 
         start_time = time.perf_counter()
-        result = None
-
         while (time.perf_counter() - start_time) < timeout:
-            result = subprocess.run(
-                shlex.split(ssh_cmd),
-                stdout=subprocess.DEVNULL,
-                stderr=subprocess.PIPE,
-                text=True,
-            )
+            try:
+                self.ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+                self.ssh.connect("localhost", port=port, username=user, password=password, timeout=1)
+                self.ssh.close()
+                return True
+            except Exception:
+                time.sleep(0.05)
 
-            if "Permission denied" in result.stderr:
-                return True # if returned SSH can connect
-            
-            time.sleep(0.05)
-
-        last_error = result.stderr.strip() if result else "No result from SSH command"
-        raise TimeoutError(f"SSH connection failed. Last error: {last_error}")
-
+        raise TimeoutError("SSH authentication failed. Server not ready.")
+    
     def delete(self):
         ...
 

--- a/src/worker_node/models/vm_output.py
+++ b/src/worker_node/models/vm_output.py
@@ -1,0 +1,8 @@
+from pydantic import BaseModel
+
+class VMOutput(BaseModel):
+    stdin: str = ""
+    stdout: str = ""
+    stderr: str = ""
+    returncode: int = -1
+    runtime: str = ""

--- a/test/files_for_transfer/test_in_vm.py
+++ b/test/files_for_transfer/test_in_vm.py
@@ -1,0 +1,25 @@
+"""
+This file contains test functions for stdout and stderr outputs.
+It includes functions to test both standard output and error outputs.
+If the test type is True, it will print to stdout; otherwise, it will raise an error to stderr.
+This is useful for verifying that the system handles both types of outputs correctly.
+BURAT
+"""
+
+def stdout_test():
+    print("This is a test output to stdout.")
+
+def stderr_test():
+    raise NotImplementedError("This is a test error to stderr.")
+
+def test_vm_output(test_type:bool=True):
+    if test_type:
+        stdout_test()
+    else:
+        stderr_test()
+
+if __name__ == "__main__":
+    import sys
+    # Take argument from command line: "stdout" or "stderr"
+    test_type = True if len(sys.argv) < 2 or sys.argv[1].lower() == "stdout" else False
+    test_vm_output(test_type)

--- a/test/test_qemu_controller.py
+++ b/test/test_qemu_controller.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import paramiko
 from src.worker_node.core.qemu_controller import QemuController, QemuStatus
 import subprocess
 
@@ -103,4 +104,37 @@ def test_qemu_boot_time():
         assert qemu.boot_time < 1000, "QEMU boot time exceeded expected threshold"
     finally:
         if qemu.status == QemuStatus.STARTED:
+            qemu.stop()
+
+
+def test_run_command_in_vm():
+    qemu = QemuController(
+        image_path,
+        cpu_count,
+        memory_allocated
+    )
+
+    test_file_path = Path("test/files_for_transfer/test_in_vm.py")
+    path_in_vm = "/root/test_in_vm"
+    try:
+        qemu.start()
+        assert qemu.status == QemuStatus.STARTED
+        assert qemu.check_ssh_connection(), "SSH connection failed after starting QEMU"        
+        assert test_file_path.exists(), "Test file for command execution does not exist"
+
+        qemu.ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+        qemu.ssh.connect("localhost", port=2222, username="root", password="root")
+        sftp = qemu.ssh.open_sftp()
+        assert sftp.put(str(test_file_path), path_in_vm), "Failed to transfer test file to VM"
+        sftp.close()
+
+        assert qemu.run_command(path_in_vm, "stdout"), "Command execution in VM failed for stdout"
+        print(qemu.run_command(path_in_vm, "stdout"))
+        assert qemu.run_command(path_in_vm, "stderr"), "Command execution in VM failed for stderr"
+        print(qemu.run_command(path_in_vm, "stderr"))
+
+
+    finally:
+        if qemu.status == QemuStatus.STARTED:
+            qemu.ssh.close()
             qemu.stop()

--- a/test/test_qemu_controller.py
+++ b/test/test_qemu_controller.py
@@ -378,7 +378,7 @@ def test_freeze_resume_vm(test_img: Path):
     time.sleep(2)
     result = subprocess.run(["ps", "-p", str(qemu.proc.pid), "-o", "%cpu="], capture_output=True, text=True)
     cpu_usage = result.stdout.strip()
-    assert cpu_usage > "0.0"
+    assert cpu_usage == "0.0"
 
     qemu.resume()
     assert "VM status: running" in qemu._send_command_to_qemu_monitor(file_socket, "info status", return_stdout=True) # type: ignore

--- a/test/test_qemu_controller.py
+++ b/test/test_qemu_controller.py
@@ -88,7 +88,7 @@ def test_get_qemu_cmd_invalid_virtualization(tmp_path: Path):
 
 
 cpu_count = 2
-memory_allocated = 500
+memory_allocated = 512
 
 def test_qemu_initialization(test_img: Path):
     qemu = QemuController(
@@ -170,7 +170,7 @@ def test_qemu_command_error(test_img: Path):
         memory_allocated
     )
     with pytest.raises(RuntimeError, match="Failed to start QEMU process due to an error in the command"):
-        cmd_error.img_path = Path("./alpine/alpine-standard-3.22.1-x86_64.iso")
+        cmd_error.img_path = Path("/home/dan/Projects/qemu-node/alpine-stndrd/alpine-standard-3.22.1-x86_64.iso")
         cmd_error.start()
 
 def test_qemu_boot_time(test_img: Path):
@@ -189,19 +189,15 @@ def test_qemu_boot_time(test_img: Path):
             qemu.stop()
 
 
-def test_run_command_in_vm():
-    qemu = QemuController(
-        image_path,
-        cpu_count,
-        memory_allocated
-    )
+def test_run_command_in_vm(test_img: Path):
+    qemu = QemuController(test_img, "linux", 2, 500)
 
     test_file_path = Path("test/files_for_transfer/test_in_vm.py")
     path_in_vm = "/root/test_in_vm"
     try:
         qemu.start()
         assert qemu.status == QemuStatus.STARTED
-        assert qemu.check_ssh_connection(), "SSH connection failed after starting QEMU"        
+        assert qemu.wait_for_ssh_connection(), "SSH connection failed after starting QEMU"        
         assert test_file_path.exists(), "Test file for command execution does not exist"
 
         qemu.ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())

--- a/test/test_qemu_controller.py
+++ b/test/test_qemu_controller.py
@@ -129,9 +129,7 @@ def test_run_command_in_vm():
         sftp.close()
 
         assert qemu.run_command(path_in_vm, "stdout"), "Command execution in VM failed for stdout"
-        print(qemu.run_command(path_in_vm, "stdout"))
         assert qemu.run_command(path_in_vm, "stderr"), "Command execution in VM failed for stderr"
-        print(qemu.run_command(path_in_vm, "stderr"))
 
 
     finally:

--- a/test/test_qemu_controller.py
+++ b/test/test_qemu_controller.py
@@ -139,28 +139,40 @@ def test_start_command_fails(test_img: Path):
         with pytest.raises(RuntimeError, match="Failed to start QEMU process"):
             qemu.start()
 
-def test_start_ssh_timeout(test_img: Path):
+@patch("src.worker_node.core.qemu_controller.subprocess.Popen")
+@patch("src.worker_node.core.qemu_controller.QemuController.create_snapshot", new=MagicMock())
+def test_start_wait_for_ssh_connection_timeout(mock_popen: MagicMock, test_img: Path):
+    fake_proc = MagicMock()
+    fake_proc.poll.return_value = None
+    fake_proc.returncode = 0
+    mock_popen.return_value = fake_proc
+
     qemu = QemuController(test_img, "linux", 2, 512)
+    qemu.ssh = MagicMock()
+    qemu.ssh.connect.side_effect = paramiko.SSHException("Unable to connect")
 
-    with patch("subprocess.Popen") as mock_popen, \
-         patch.object(QemuController, "wait_for_ssh_connection", return_value=False):
-
-        process_mock = MagicMock()
-        process_mock.poll.return_value = None
-        mock_popen.return_value = process_mock
-
+    with pytest.raises(RuntimeError, match="SSH authentication failed"):
         qemu.start()
-        assert qemu.status == QemuStatus.STARTED
 
-
+@patch("src.worker_node.core.qemu_controller.QemuController.create_snapshot", new=MagicMock())
 def test_qemu_stop(test_img: Path):
-    with patch.object(QemuController, 'wait_for_ssh_connection', return_value=True):
+    with patch.object(QemuController, 'wait_for_ssh_connection', return_value=True), \
+         patch("subprocess.Popen") as mock_popen:
+        
+        mock_proc = MagicMock()
+        mock_proc.returncode = 0
+        mock_proc.poll.return_value = None
+        mock_popen.return_value = mock_proc
+
         qemu = QemuController(test_img, "linux", 2, 500)
         qemu.start()
         assert qemu.status == QemuStatus.STARTED
-        
+
         qemu.stop()
         assert qemu.status == QemuStatus.STOPPED
+        mock_proc.terminate.assert_called_once()
+
+        mock_proc.poll.assert_called()
 
 def test_qemu_stop_before_start(test_img: Path):
     with patch.object(QemuController, "wait_for_ssh_connection", return_value=True):

--- a/test/test_qemu_controller.py
+++ b/test/test_qemu_controller.py
@@ -375,7 +375,7 @@ def test_freeze_resume_vm(test_img: Path):
     qemu.freeze()
     assert "VM status: paused" in qemu._send_command_to_qemu_monitor(file_socket, "info status", return_stdout=True) # type: ignore
 
-    time.sleep(2)
+    time.sleep(10)
     result = subprocess.run(["ps", "-p", str(qemu.proc.pid), "-o", "%cpu="], capture_output=True, text=True)
     cpu_usage = result.stdout.strip()
     assert cpu_usage == "0.0"

--- a/test/test_qemu_controller.py
+++ b/test/test_qemu_controller.py
@@ -90,18 +90,17 @@ def test_get_qemu_cmd_invalid_virtualization(tmp_path: Path):
 cpu_count = 2
 memory_allocated = 512
 
-def test_qemu_initialization(test_img: Path):
-    qemu = QemuController(
-        test_img,
-		"linux",
-        cpu_count,
-        memory_allocated
-    )
+def test_qemu_initialization_mocked(test_img:Path):
+    cpu_count = 2
+    memory_allocated = 500
+
+    with patch.object(Path, "exists", return_value=True):
+        qemu = QemuController(test_img, "linux", cpu_count, memory_allocated)
+
     assert qemu.img_path == test_img
     assert qemu.cpu_count == cpu_count
     assert qemu.memory_allocated == memory_allocated
     assert qemu.status == QemuStatus.STOPPED
-    os.remove(test_img)
 
 def test_qemu_start(test_img: Path):
     qemu = QemuController(test_img, "linux", 2, 500)
@@ -120,33 +119,92 @@ def test_qemu_start(test_img: Path):
         if qemu.status == QemuStatus.STARTED:
             qemu.stop()
 
-def test_qemu_stop(test_img: Path):
-    qemu = QemuController(
-        Path("./alpine.qcow2"),
-		"linux",
-        cpu_count,
-        memory_allocated
-    )
-    try:
+def test_start_already_started(test_img: Path):    
+    qemu = QemuController(test_img, "linux", 2, 512)
+    qemu.status = QemuStatus.STARTED
+
+    with pytest.raises(RuntimeError, match="QEMU is already running"):
+        qemu.start()
+
+def test_start_command_fails(test_img: Path):
+
+    qemu = QemuController(test_img, "linux", 2, 512)
+
+    with patch("subprocess.Popen") as mock_popen:
+        process_mock = MagicMock()
+        process_mock.poll.return_value = 1
+        process_mock.returncode = 1
+        mock_popen.return_value = process_mock
+
+        with pytest.raises(RuntimeError, match="Failed to start QEMU process"):
+            qemu.start()
+
+def test_start_ssh_timeout(test_img: Path):
+    qemu = QemuController(test_img, "linux", 2, 512)
+
+    with patch("subprocess.Popen") as mock_popen, \
+         patch.object(QemuController, "wait_for_ssh_connection", return_value=False):
+
+        process_mock = MagicMock()
+        process_mock.poll.return_value = None
+        mock_popen.return_value = process_mock
+
         qemu.start()
         assert qemu.status == QemuStatus.STARTED
-        assert qemu.wait_for_ssh_connection(), "SSH connection failed after starting QEMU"
-    finally:
+
+
+def test_qemu_stop(test_img: Path):
+    with patch.object(QemuController, 'wait_for_ssh_connection', return_value=True):
+        qemu = QemuController(test_img, "linux", 2, 500)
+        qemu.start()
+        assert qemu.status == QemuStatus.STARTED
+        
         qemu.stop()
         assert qemu.status == QemuStatus.STOPPED
-        proc_check = subprocess.run(
-            ["pgrep", "-f", "qemu-system-x86_64"],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            text=True
-        )
-        assert proc_check.returncode is not None, "QEMU process did not stop properly"
-        # Double check that stopping again raises an error
-        try:
+
+def test_qemu_stop_before_start(test_img: Path):
+    with patch.object(QemuController, "wait_for_ssh_connection", return_value=True):
+        qemu = QemuController(test_img, "linux", 2, 500)
+        with pytest.raises(RuntimeError, match="QEMU is not STARTED"):
             qemu.stop()
-            assert False, "Expected RuntimeError not raised when stopping already stopped QEMU"
-        except RuntimeError as e:
-            assert "No QEMU process to stop" in str(e) or isinstance(e, RuntimeError)
+
+        qemu.status = QemuStatus.STARTED
+        qemu.proc = MagicMock()
+
+        qemu.stop()
+        assert qemu.status == QemuStatus.STOPPED
+        qemu.proc.terminate.assert_called_once()
+
+def test_wait_for_ssh_connection_success(test_img: Path):
+    qemu = QemuController(test_img, "linux", 2, 512)
+    qemu.ssh = MagicMock()
+
+    # simulate successful connection on first try
+    qemu.ssh.connect.return_value = None
+
+    assert qemu.wait_for_ssh_connection(timeout=1) is True
+    qemu.ssh.connect.assert_called_once_with(
+        "localhost", port=2222, username="root", password="root", timeout=1
+    )
+
+def test_wait_for_ssh_connection_timeout(test_img: Path):
+    qemu = QemuController(test_img, "linux", 2, 512)
+    qemu.ssh = MagicMock()
+
+    qemu.ssh.connect.side_effect = paramiko.SSHException("Unable to connect")
+
+    with pytest.raises(TimeoutError, match="SSH authentication failed"):
+        qemu.wait_for_ssh_connection(timeout=1)
+
+def test_wait_for_ssh_connection_eventual_success(test_img: Path):
+    qemu = QemuController(test_img, "linux", 2, 512)
+    qemu.ssh = MagicMock()
+
+    qemu.ssh.connect.side_effect = [paramiko.SSHException("Fail 1"), None]
+
+    assert qemu.wait_for_ssh_connection(timeout=2) is True
+    assert qemu.ssh.connect.call_count == 2
+
 
 def test_qemu_missing_image(test_img: Path):
     with patch.object(QemuController, "__init__", return_value=None):
@@ -162,6 +220,7 @@ def test_qemu_missing_image(test_img: Path):
             no_image.start()
             assert False, "Expected RuntimeError not raised for missing image"
 
+# ======================================================================== EDIT FILE PATH
 def test_qemu_command_error(test_img: Path):
     cmd_error = QemuController(
         test_img,
@@ -172,6 +231,7 @@ def test_qemu_command_error(test_img: Path):
     with pytest.raises(RuntimeError, match="Failed to start QEMU process due to an error in the command"):
         cmd_error.img_path = Path("/home/dan/Projects/qemu-node/alpine-stndrd/alpine-standard-3.22.1-x86_64.iso")
         cmd_error.start()
+# ======================================================================== EDIT FILE PATH
 
 def test_qemu_boot_time(test_img: Path):
     qemu = QemuController(
@@ -205,12 +265,63 @@ def test_run_command_in_vm(test_img: Path):
         sftp = qemu.ssh.open_sftp()
         assert sftp.put(str(test_file_path), path_in_vm), "Failed to transfer test file to VM"
         sftp.close()
+        qemu.ssh.close()
 
-        assert qemu.run_command(path_in_vm, "stdout"), "Command execution in VM failed for stdout"
-        assert qemu.run_command(path_in_vm, "stderr"), "Command execution in VM failed for stderr"
+        assert qemu.run_command(["test_in_vm", "stdout"]), "Command execution in VM failed for stdout"
+        assert qemu.run_command(["test_in_vm", "stderr"]), "Command execution in VM failed for stderr"
 
 
     finally:
         if qemu.status == QemuStatus.STARTED:
-            qemu.ssh.close()
             qemu.stop()
+    os.remove(test_img)
+
+def test_run_command_fails_ssh_connection(test_img: Path):
+    qemu = QemuController(test_img, "linux", 2, 500)
+    qemu.status = QemuStatus.STARTED
+
+    with patch.object(qemu, "wait_for_ssh_connection", return_value=True), \
+        patch.object(qemu.ssh, "connect", side_effect=paramiko.SSHException("Unable to connect")):
+        with pytest.raises(TimeoutError, match="SSH error"):
+            qemu.run_command(["ls", ""],timeout=1)
+    
+    os.remove(test_img)
+
+def test_run_command_exec_times_out(test_img: Path):
+    qemu = QemuController(test_img, "linux", 2, 500)
+    qemu.status = QemuStatus.STARTED
+
+    with patch.object(qemu.ssh, "connect", return_value=None), \
+         patch.object(qemu.ssh, "exec_command", side_effect=Exception("Exec failed")):
+        with pytest.raises(TimeoutError, match="Command execution timed out"):
+            qemu.run_command(["ls", ""],timeout=1)
+    
+    os.remove(test_img)
+
+def test_run_command_non_zero_return_code(test_img: Path):
+    qemu = QemuController(test_img, "linux", 2, 500)
+    qemu.status = QemuStatus.STARTED
+
+    fake_stdout = MagicMock()
+    fake_stdout.read.return_value = b"some error output"
+    fake_stdout.channel.recv_exit_status.return_value = 1
+
+    fake_stderr = MagicMock()
+    fake_stderr.read.return_value = b"error details"
+
+    with patch.object(qemu.ssh, "connect", return_value=None), \
+         patch.object(qemu.ssh, "exec_command", return_value=(None, fake_stdout, fake_stderr)):
+        output = qemu.run_command(["ls", ""])
+        assert output.returncode == 1
+        assert "some error output" in output.stdout
+    
+    os.remove(test_img)
+
+def test_run_command_qemu_not_started(test_img: Path):
+    qemu = QemuController(test_img, "linux", 2, 500)
+    qemu.status = QemuStatus.STOPPED
+
+    with pytest.raises(RuntimeError, match="QEMU is not STARTED. Cannot run command."):
+        qemu.run_command(["ls", ""])
+    
+    os.remove(test_img)


### PR DESCRIPTION
Add feature to send stdin and return stdout or stderr

Some setup settings have to be tuned in order to run--

**Pre-requisites**
snapshot/qcow2:
python3

sshd configs:
permitrootlogin yes
passwordauthentication yes

alpine host:
hostname: root
password: root